### PR TITLE
[ Upgrade librdkafka compiler to 'IBM Open XL C/C++ 2.1 for z/OS' ]

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -8,7 +8,9 @@ export ZOPEN_TYPE="GIT"
 export ZOPEN_RUNTIME_DEPS="bash"
 export ZOPEN_COMP="clang"
 
-export ZOPEN_EXTRA_CFLAGS="-Wno-error -mzos-target=zosv2r4 -I../src"
+export ZOPEN_EXTRA_CFLAGS="-Werror -mzos-target=zosv2r4 -I../src"
+export ZOPEN_EXTRA_CXXFLAGS="-Werror"
+export ZOPEN_EXTRA_LDFLAGS="-m64"
 
 export ZOPEN_EXTRA_CPPFLAGS="-D_OPEN_SYS_SOCK_IPV6 -D_UNIX03_SOURCE -D_UNIX03_THREADS -D_XOPEN_SOURCE_EXTENDED=1 -D_POSIX_C_SOURCE=200112L -D_POSIX_SOURCE -DPOSIX_SIGNALS -mzos-target=zosv2r4 -I../src-cpp"
 

--- a/patches/examples/describe_cluster.c.patch
+++ b/patches/examples/describe_cluster.c.patch
@@ -1,0 +1,18 @@
+diff --git a/examples/describe_cluster.c b/examples/describe_cluster.c
+index c37da17f..b0bf566a 100644
+--- a/examples/describe_cluster.c
++++ b/examples/describe_cluster.c
+@@ -36,11 +36,13 @@
+ #include <stdlib.h>
+ #include <stdarg.h>
+ 
++#ifndef __MVS__
+ #ifdef _WIN32
+ #include "../win32/wingetopt.h"
+ #else
+ #include <getopt.h>
+ #endif
++#endif
+ 
+ 
+ /* Typical include path would be <librdkafka/rdkafka.h>, but this program

--- a/patches/examples/describe_topics.c.patch
+++ b/patches/examples/describe_topics.c.patch
@@ -1,0 +1,18 @@
+diff --git a/examples/describe_topics.c b/examples/describe_topics.c
+index 5b7425ef..bdc53f33 100644
+--- a/examples/describe_topics.c
++++ b/examples/describe_topics.c
+@@ -36,11 +36,13 @@
+ #include <stdlib.h>
+ #include <stdarg.h>
+ 
++#ifndef __MVS__
+ #ifdef _WIN32
+ #include "../win32/wingetopt.h"
+ #else
+ #include <getopt.h>
+ #endif
++#endif
+ 
+ 
+ /* Typical include path would be <librdkafka/rdkafka.h>, but this program

--- a/patches/examples/list_offsets.c.patch
+++ b/patches/examples/list_offsets.c.patch
@@ -1,0 +1,18 @@
+diff --git a/examples/list_offsets.c b/examples/list_offsets.c
+index f84c11c1..81e1e61e 100644
+--- a/examples/list_offsets.c
++++ b/examples/list_offsets.c
+@@ -37,11 +37,13 @@
+ #include <stdlib.h>
+ #include <stdarg.h>
+ 
++#ifndef __MVS__
+ #ifdef _WIN32
+ #include "../win32/wingetopt.h"
+ #else
+ #include <getopt.h>
+ #endif
++#endif
+ 
+ 
+ /* Typical include path would be <librdkafka/rdkafka.h>, but this program

--- a/patches/src-cpp/rdkafkacpp.h.patch
+++ b/patches/src-cpp/rdkafkacpp.h.patch
@@ -1,0 +1,308 @@
+diff --git a/src-cpp/rdkafkacpp.h b/src-cpp/rdkafkacpp.h
+index eb04afa1..dd916fcf 100644
+--- a/src-cpp/rdkafkacpp.h
++++ b/src-cpp/rdkafkacpp.h
+@@ -66,18 +66,22 @@
+ typedef SSIZE_T ssize_t;
+ #endif
+ #endif
+-#undef RD_EXPORT
++#undef RD_EXPORT_CPP
+ #ifdef LIBRDKAFKA_STATICLIB
+-#define RD_EXPORT
++#define RD_EXPORT_CPP
+ #else
+ #ifdef LIBRDKAFKACPP_EXPORTS
+-#define RD_EXPORT __declspec(dllexport)
++#define RD_EXPORT_CPP __declspec(dllexport)
+ #else
+-#define RD_EXPORT __declspec(dllimport)
++#define RD_EXPORT_CPP __declspec(dllimport)
+ #endif
+ #endif
+ #else
+-#define RD_EXPORT
++#ifdef __MVS__
++#define RD_EXPORT_CPP __attribute__((visibility("default")))
++#else
++#define RD_EXPORT_CPP
++#endif
+ #endif
+ 
+ /**@endcond*/
+@@ -119,20 +123,20 @@ namespace RdKafka {
+  *
+  * @sa See RD_KAFKA_VERSION for how to parse the integer format.
+  */
+-RD_EXPORT
++RD_EXPORT_CPP
+ int version();
+ 
+ /**
+  * @brief Returns the librdkafka version as string.
+  */
+-RD_EXPORT
++RD_EXPORT_CPP
+ std::string version_str();
+ 
+ /**
+  * @brief Returns a CSV list of the supported debug contexts
+  *        for use with Conf::Set("debug", ..).
+  */
+-RD_EXPORT
++RD_EXPORT_CPP
+ std::string get_debug_contexts();
+ 
+ /**
+@@ -144,7 +148,7 @@ std::string get_debug_contexts();
+  * \p wait_destroyed() function can be used for applications where
+  * a clean shutdown is required.
+  */
+-RD_EXPORT
++RD_EXPORT_CPP
+ int wait_destroyed(int timeout_ms);
+ 
+ /**
+@@ -157,7 +161,7 @@ int wait_destroyed(int timeout_ms);
+  * @remark Memory allocated by mem_malloc() must be freed using
+  *         mem_free().
+  */
+-RD_EXPORT
++RD_EXPORT_CPP
+ void *mem_malloc(size_t size);
+ 
+ /**
+@@ -173,7 +177,7 @@ void *mem_malloc(size_t size);
+  * @remark mem_free() must only be used for pointers returned by APIs
+  *         that explicitly mention using this function for freeing.
+  */
+-RD_EXPORT
++RD_EXPORT_CPP
+ void mem_free(void *ptr);
+ 
+ /**@}*/
+@@ -551,7 +555,7 @@ enum ErrorCode {
+ /**
+  * @brief Returns a human readable representation of a kafka error.
+  */
+-RD_EXPORT
++RD_EXPORT_CPP
+ std::string err2str(RdKafka::ErrorCode err);
+ 
+ 
+@@ -613,7 +617,7 @@ class KafkaConsumer;
+  *
+  * Error objects must be deleted explicitly to free its resources.
+  */
+-class RD_EXPORT Error {
++class RD_EXPORT_CPP Error {
+  public:
+   /**
+    * @brief Create error object.
+@@ -698,7 +702,7 @@ class RD_EXPORT Error {
+  * serve queued delivery report callbacks.
+ 
+  */
+-class RD_EXPORT DeliveryReportCb {
++class RD_EXPORT_CPP DeliveryReportCb {
+  public:
+   /**
+    * @brief Delivery report callback.
+@@ -737,7 +741,7 @@ class RD_EXPORT DeliveryReportCb {
+  * serve queued SASL/OAUTHBEARER token refresh callbacks (when
+  * OAUTHBEARER is the SASL mechanism).
+  */
+-class RD_EXPORT OAuthBearerTokenRefreshCb {
++class RD_EXPORT_CPP OAuthBearerTokenRefreshCb {
+  public:
+   /**
+    * @brief SASL/OAUTHBEARER token refresh callback class.
+@@ -762,7 +766,7 @@ class RD_EXPORT OAuthBearerTokenRefreshCb {
+  *
+  * @sa RdKafka::Conf::set() \c "partitioner_cb"
+  */
+-class RD_EXPORT PartitionerCb {
++class RD_EXPORT_CPP PartitionerCb {
+  public:
+   /**
+    * @brief Partitioner callback
+@@ -824,7 +828,7 @@ class PartitionerKeyPointerCb {
+  *
+  * @sa RdKafka::Event
+  */
+-class RD_EXPORT EventCb {
++class RD_EXPORT_CPP EventCb {
+  public:
+   /**
+    * @brief Event callback
+@@ -841,7 +845,7 @@ class RD_EXPORT EventCb {
+ /**
+  * @brief Event object class as passed to the EventCb callback.
+  */
+-class RD_EXPORT Event {
++class RD_EXPORT_CPP Event {
+  public:
+   /** @brief Event type */
+   enum Type {
+@@ -936,7 +940,7 @@ class RD_EXPORT Event {
+ /**
+  * @brief Consume callback class
+  */
+-class RD_EXPORT ConsumeCb {
++class RD_EXPORT_CPP ConsumeCb {
+  public:
+   /**
+    * @brief The consume callback is used with
+@@ -955,7 +959,7 @@ class RD_EXPORT ConsumeCb {
+ /**
+  * @brief \b KafkaConsumer: Rebalance callback class
+  */
+-class RD_EXPORT RebalanceCb {
++class RD_EXPORT_CPP RebalanceCb {
+  public:
+   /**
+    * @brief Group rebalance callback for use with RdKafka::KafkaConsumer
+@@ -1037,7 +1041,7 @@ class RD_EXPORT RebalanceCb {
+ /**
+  * @brief Offset Commit callback class
+  */
+-class RD_EXPORT OffsetCommitCb {
++class RD_EXPORT_CPP OffsetCommitCb {
+  public:
+   /**
+    * @brief Set offset commit callback for use with consumer groups
+@@ -1068,7 +1072,7 @@ class RD_EXPORT OffsetCommitCb {
+  *
+  * @remark Class instance must outlive the RdKafka client instance.
+  */
+-class RD_EXPORT SslCertificateVerifyCb {
++class RD_EXPORT_CPP SslCertificateVerifyCb {
+  public:
+   /**
+    * @brief SSL broker certificate verification callback.
+@@ -1123,7 +1127,7 @@ class RD_EXPORT SslCertificateVerifyCb {
+  * @brief \b Portability: SocketCb callback class
+  *
+  */
+-class RD_EXPORT SocketCb {
++class RD_EXPORT_CPP SocketCb {
+  public:
+   /**
+    * @brief Socket callback
+@@ -1149,7 +1153,7 @@ class RD_EXPORT SocketCb {
+  * @brief \b Portability: OpenCb callback class
+  *
+  */
+-class RD_EXPORT OpenCb {
++class RD_EXPORT_CPP OpenCb {
+  public:
+   /**
+    * @brief Open callback
+@@ -1188,7 +1192,7 @@ class RD_EXPORT OpenCb {
+  *
+  * @sa CONFIGURATION.md for the full list of supported properties.
+  */
+-class RD_EXPORT Conf {
++class RD_EXPORT_CPP Conf {
+  public:
+   /**
+    * @brief Configuration object type
+@@ -1510,7 +1514,7 @@ class RD_EXPORT Conf {
+ /**
+  * @brief Base handle, super class for specific clients.
+  */
+-class RD_EXPORT Handle {
++class RD_EXPORT_CPP Handle {
+  public:
+   virtual ~Handle() {
+   }
+@@ -1940,7 +1944,7 @@ class RD_EXPORT Handle {
+  * Is typically used with std::vector<RdKafka::TopicPartition*> to provide
+  * a list of partitions for different operations.
+  */
+-class RD_EXPORT TopicPartition {
++class RD_EXPORT_CPP TopicPartition {
+  public:
+   /**
+    * @brief Create topic+partition object for \p topic and \p partition.
+@@ -2001,7 +2005,7 @@ class RD_EXPORT TopicPartition {
+  * @brief Topic handle
+  *
+  */
+-class RD_EXPORT Topic {
++class RD_EXPORT_CPP Topic {
+  public:
+   /**
+    * @brief Unassigned partition.
+@@ -2104,7 +2108,7 @@ class RD_EXPORT Topic {
+  *
+  */
+ 
+-class RD_EXPORT MessageTimestamp {
++class RD_EXPORT_CPP MessageTimestamp {
+  public:
+   /*! Message timestamp type */
+   enum MessageTimestampType {
+@@ -2127,7 +2131,7 @@ class RD_EXPORT MessageTimestamp {
+  *
+  * @remark Requires Apache Kafka >= 0.11.0 brokers
+  */
+-class RD_EXPORT Headers {
++class RD_EXPORT_CPP Headers {
+  public:
+   virtual ~Headers() = 0;
+ 
+@@ -2370,7 +2374,7 @@ class RD_EXPORT Headers {
+  * an error event.
+  *
+  */
+-class RD_EXPORT Message {
++class RD_EXPORT_CPP Message {
+  public:
+   /** @brief Message persistence status can be used by the application to
+    *         find out if a produced message was persisted in the topic log. */
+@@ -2535,7 +2539,7 @@ class RD_EXPORT Message {
+  * RdKafka::Consumer::consume_callback() methods that take a queue as the first
+  * parameter for more information.
+  */
+-class RD_EXPORT Queue {
++class RD_EXPORT_CPP Queue {
+  public:
+   /**
+    * @brief Create Queue object
+@@ -2610,7 +2614,7 @@ class RD_EXPORT Queue {
+  *
+  * This class currently does not have any public methods.
+  */
+-class RD_EXPORT ConsumerGroupMetadata {
++class RD_EXPORT_CPP ConsumerGroupMetadata {
+  public:
+   virtual ~ConsumerGroupMetadata() = 0;
+ };
+@@ -2632,7 +2636,7 @@ class RD_EXPORT ConsumerGroupMetadata {
+  * Currently supports the \c range and \c roundrobin partition assignment
+  * strategies (see \c partition.assignment.strategy)
+  */
+-class RD_EXPORT KafkaConsumer : public virtual Handle {
++class RD_EXPORT_CPP KafkaConsumer : public virtual Handle {
+  public:
+   /**
+    * @brief Creates a KafkaConsumer.
+@@ -3047,7 +3051,7 @@ class RD_EXPORT KafkaConsumer : public virtual Handle {
+  *
+  * A simple non-balanced, non-group-aware, consumer.
+  */
+-class RD_EXPORT Consumer : public virtual Handle {
++class RD_EXPORT_CPP Consumer : public virtual Handle {
+  public:
+   /**
+    * @brief Creates a new Kafka consumer handle.
+@@ -3229,7 +3233,7 @@ class RD_EXPORT Consumer : public virtual Handle {
+ /**
+  * @brief Producer
+  */
+-class RD_EXPORT Producer : public virtual Handle {
++class RD_EXPORT_CPP Producer : public virtual Handle {
+  public:
+   /**
+    * @brief Creates a new Kafka producer handle.

--- a/patches/src/rdaddr.c.patch
+++ b/patches/src/rdaddr.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/rdaddr.c b/src/rdaddr.c
-index 6fb2c66c..6b2306b0 100644
+index 6fb2c66c..44705a70 100644
 --- a/src/rdaddr.c
 +++ b/src/rdaddr.c
 @@ -32,19 +32,38 @@
@@ -66,7 +66,7 @@ index 6fb2c66c..6b2306b0 100644
  
                           (flags & RD_SOCKADDR2STR_F_PORT) ? portstr : NULL,
  
-@@ -87,10 +113,15 @@ const char *rd_sockaddr2str(const void *addr, int flags) {
+@@ -87,29 +113,54 @@ const char *rd_sockaddr2str(const void *addr, int flags) {
                  if (flags & RD_SOCKADDR2STR_F_PORT) {
                          size_t len = strlen(ret[reti]);
                          rd_snprintf(
@@ -82,7 +82,20 @@ index 6fb2c66c..6b2306b0 100644
                  return ret[reti];
          }
  
-@@ -104,12 +135,27 @@ const char *rd_sockaddr2str(const void *addr, int flags) {
+ 
+         /* Error-case */
+-        rd_snprintf(ret[reti], sizeof(ret[reti]), "<unsupported:%s>",
+-                    rd_family2str(a->sinx_family));
++        rd_snprintf(
++#ifdef __MVS__
++                ret[reti], size_of_ret,
++#else                
++                ret[reti], sizeof(ret[reti]),
++#endif                
++                "<unsupported:%s>", rd_family2str(a->sinx_family));
+ 
+         return ret[reti];
+ }
  
  
  const char *rd_addrinfo_prepare(const char *nodesvc, char **node, char **svc) {
@@ -111,7 +124,7 @@ index 6fb2c66c..6b2306b0 100644
          *snode = '\0';
          *ssvc  = '\0';
  
-@@ -141,7 +187,11 @@ const char *rd_addrinfo_prepare(const char *nodesvc, char **node, char **svc) {
+@@ -141,7 +192,11 @@ const char *rd_addrinfo_prepare(const char *nodesvc, char **node, char **svc) {
  
          if (nodelen) {
                  /* Truncate nodename if necessary. */

--- a/patches/src/rdhttp.c.patch
+++ b/patches/src/rdhttp.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/rdhttp.c b/src/rdhttp.c
-index cea2d1c9..17d88e99 100644
+index cea2d1c9..b98555b1 100644
 --- a/src/rdhttp.c
 +++ b/src/rdhttp.c
 @@ -43,6 +43,36 @@
@@ -39,6 +39,15 @@ index cea2d1c9..17d88e99 100644
  
  void rd_http_error_destroy(rd_http_error_t *herr) {
          rd_free(herr);
+@@ -139,7 +169,7 @@ rd_http_error_t *rd_http_req_init(rd_http_req_t *hreq, const char *url) {
+         hreq->hreq_buf = rd_buf_new(1, 1024);
+ 
+         curl_easy_setopt(hreq->hreq_curl, CURLOPT_URL, url);
+-        curl_easy_setopt(hreq->hreq_curl, CURLOPT_PROTOCOLS,
++        curl_easy_setopt(hreq->hreq_curl, CURLOPT_PROTOCOLS_STR,
+                          CURLPROTO_HTTP | CURLPROTO_HTTPS);
+         curl_easy_setopt(hreq->hreq_curl, CURLOPT_MAXREDIRS, 16);
+         curl_easy_setopt(hreq->hreq_curl, CURLOPT_TIMEOUT, 30);
 @@ -320,6 +350,30 @@ rd_http_error_t *rd_http_post_expect_json(rd_kafka_t *rk,
                           post_fields_size);
          curl_easy_setopt(hreq.hreq_curl, CURLOPT_POSTFIELDS, post_fields);

--- a/patches/tests/0019-list_groups.c.patch
+++ b/patches/tests/0019-list_groups.c.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/0019-list_groups.c b/tests/0019-list_groups.c
+index 3337e347..a991f586 100644
+--- a/tests/0019-list_groups.c
++++ b/tests/0019-list_groups.c
+@@ -127,7 +127,7 @@ list_groups(rd_kafka_t *rk, char **groups, int group_cnt, const char *desc) {
+                 if (err) {
+                         TEST_SAY("Failed to list group %s: %s\n", groups[i],
+                                  rd_kafka_err2str(err));
+-                        fails++;
++                        fails = fails + 1;
+                         continue;
+                 }
+ 

--- a/patches/tests/0076-produce_retry.c.patch
+++ b/patches/tests/0076-produce_retry.c.patch
@@ -1,0 +1,56 @@
+diff --git a/tests/0076-produce_retry.c b/tests/0076-produce_retry.c
+index 2ea9dfa4..bb043013 100644
+--- a/tests/0076-produce_retry.c
++++ b/tests/0076-produce_retry.c
+@@ -58,6 +58,51 @@ is_fatal_cb(rd_kafka_t *rk, rd_kafka_resp_err_t err, const char *reason) {
+  * reject all the rest (connection refused) to make sure we're only
+  * playing with one single broker for this test. */
+ 
++/** Fix compilation warning due to -Wmacro-redefined flag: 
++ * Undefine macros already defined in librdkafka/src/queue.h */
++#undef SLIST_FOREACH
++#undef SLIST_FOREACH_SAFE
++#undef SLIST_INIT
++#undef SLIST_INSERT_AFTER
++#undef SLIST_INSERT_HEAD
++#undef SLIST_REMOVE
++#undef SLIST_REMOVE_AFTER
++#undef SLIST_REMOVE_HEAD
++#undef STAILQ_CONCAT
++#undef STAILQ_EMPTY
++#undef STAILQ_FOREACH
++#undef STAILQ_INIT
++#undef STAILQ_INSERT_AFTER
++#undef STAILQ_INSERT_HEAD
++#undef STAILQ_INSERT_TAIL
++#undef STAILQ_LAST
++#undef STAILQ_REMOVE
++#undef STAILQ_REMOVE_HEAD
++#undef LIST_EMPTY
++#undef LIST_FOREACH
++#undef LIST_FOREACH_SAFE
++#undef LIST_INIT
++#undef LIST_INSERT_AFTER
++#undef LIST_INSERT_BEFORE
++#undef LIST_INSERT_HEAD
++#undef LIST_REMOVE
++#undef TAILQ_HEAD
++#undef TAILQ_HEAD_INITIALIZER
++#undef TAILQ_ENTRY
++#undef TAILQ_CONCAT
++#undef TAILQ_EMPTY
++#undef TAILQ_FOREACH
++#undef TAILQ_FOREACH_SAFE
++#undef TAILQ_FOREACH_REVERSE
++#undef TAILQ_FOREACH_REVERSE_SAFE
++#undef TAILQ_INIT
++#undef TAILQ_INSERT_AFTER
++#undef TAILQ_INSERT_HEAD
++#undef TAILQ_INSERT_TAIL
++#undef TAILQ_REMOVE
++#undef TAILQ_END
++#undef TAILQ_INSERT_BEFORE
++
+ #include "sockem_ctrl.h"
+ 
+ 

--- a/patches/tests/0085-headers.cpp.patch
+++ b/patches/tests/0085-headers.cpp.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/0085-headers.cpp b/tests/0085-headers.cpp
+index aa9c4246..5aff8b75 100644
+--- a/tests/0085-headers.cpp
++++ b/tests/0085-headers.cpp
+@@ -98,7 +98,7 @@ static void test_headers(RdKafka::Headers *produce_headers,
+     RdKafka::Message *msg = consumer->consume(10 * 1000);
+ 
+     if (msg->err() == RdKafka::ERR_NO_ERROR) {
+-      cnt++;
++      cnt = cnt + 1;
+       RdKafka::Headers *headers = msg->headers();
+       if (compare_headers->size() > 0) {
+         assert_all_headers_match(headers, compare_headers);

--- a/patches/tests/0094-idempotence_msg_timeout.c.patch
+++ b/patches/tests/0094-idempotence_msg_timeout.c.patch
@@ -1,0 +1,56 @@
+diff --git a/tests/0094-idempotence_msg_timeout.c b/tests/0094-idempotence_msg_timeout.c
+index 4f2b3cbe..530eec40 100644
+--- a/tests/0094-idempotence_msg_timeout.c
++++ b/tests/0094-idempotence_msg_timeout.c
+@@ -88,6 +88,51 @@
+  * We chose to go with option 6d.
+  */
+ 
++/** Avoid compilation warning due to -Wmacro-redefined flag: 
++ * Undefine macros already defined in librdkafka/src/queue.h */
++
++#undef SLIST_FOREACH
++#undef SLIST_FOREACH_SAFE
++#undef SLIST_INIT
++#undef SLIST_INSERT_AFTER
++#undef SLIST_INSERT_HEAD
++#undef SLIST_REMOVE
++#undef SLIST_REMOVE_AFTER
++#undef SLIST_REMOVE_HEAD
++#undef STAILQ_CONCAT
++#undef STAILQ_EMPTY
++#undef STAILQ_FOREACH
++#undef STAILQ_INIT
++#undef STAILQ_INSERT_AFTER
++#undef STAILQ_INSERT_HEAD
++#undef STAILQ_INSERT_TAIL
++#undef STAILQ_LAST
++#undef STAILQ_REMOVE
++#undef STAILQ_REMOVE_HEAD
++#undef LIST_EMPTY
++#undef LIST_FOREACH
++#undef LIST_FOREACH_SAFE
++#undef LIST_INIT
++#undef LIST_INSERT_AFTER
++#undef LIST_INSERT_BEFORE
++#undef LIST_INSERT_HEAD
++#undef LIST_REMOVE
++#undef TAILQ_HEAD
++#undef TAILQ_HEAD_INITIALIZER
++#undef TAILQ_ENTRY
++#undef TAILQ_CONCAT
++#undef TAILQ_EMPTY
++#undef TAILQ_FOREACH
++#undef TAILQ_FOREACH_SAFE
++#undef TAILQ_FOREACH_REVERSE
++#undef TAILQ_FOREACH_REVERSE_SAFE
++#undef TAILQ_INIT
++#undef TAILQ_INSERT_AFTER
++#undef TAILQ_INSERT_HEAD
++#undef TAILQ_INSERT_TAIL
++#undef TAILQ_REMOVE
++#undef TAILQ_END
++#undef TAILQ_INSERT_BEFORE
+ 
+ #include <stdarg.h>
+ #include <errno.h>

--- a/patches/tests/0113-cooperative_rebalance.cpp.patch
+++ b/patches/tests/0113-cooperative_rebalance.cpp.patch
@@ -1,0 +1,17 @@
+diff --git a/tests/0113-cooperative_rebalance.cpp b/tests/0113-cooperative_rebalance.cpp
+index e94b1b78..85eea594 100644
+--- a/tests/0113-cooperative_rebalance.cpp
++++ b/tests/0113-cooperative_rebalance.cpp
+@@ -26,11 +26,11 @@
+  * POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
++#include <iostream>
+ extern "C" {
+ #include "../src/rdkafka_protocol.h"
+ #include "test.h"
+ }
+-#include <iostream>
+ #include <map>
+ #include <set>
+ #include <algorithm>

--- a/patches/tests/Makefile.patch
+++ b/patches/tests/Makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/Makefile b/tests/Makefile
+index 543639e4..49ca2d75 100644
+--- a/tests/Makefile
++++ b/tests/Makefile
+@@ -9,7 +9,7 @@ OBJS	 += test.o rusage.o testcpp.o \
+ 		sockem_ctrl.o
+ CFLAGS += -I../src
+ CXXFLAGS += -I../src -I../src-cpp
+-LDFLAGS += -rdynamic -L../src -L../src-cpp
++LDFLAGS += -L../src -L../src-cpp
+ 
+ # Latest Kafka version
+ KAFKA_VERSION?=3.4.0

--- a/patches/tests/sockem_ctrl.c.patch
+++ b/patches/tests/sockem_ctrl.c.patch
@@ -1,0 +1,57 @@
+diff --git a/tests/sockem_ctrl.c b/tests/sockem_ctrl.c
+index 4396d273..21dfb6f2 100644
+--- a/tests/sockem_ctrl.c
++++ b/tests/sockem_ctrl.c
+@@ -34,6 +34,52 @@
+ 
+ #include "test.h"
+ #include "sockem.h"
++
++/** Avoid compilation warning due to -Wmacro-redefined flag: 
++ * Undefine macros already defined in librdkafka/src/queue.h */
++#undef SLIST_FOREACH
++#undef SLIST_FOREACH_SAFE
++#undef SLIST_INIT
++#undef SLIST_INSERT_AFTER
++#undef SLIST_INSERT_HEAD
++#undef SLIST_REMOVE
++#undef SLIST_REMOVE_AFTER
++#undef SLIST_REMOVE_HEAD
++#undef STAILQ_CONCAT
++#undef STAILQ_EMPTY
++#undef STAILQ_FOREACH
++#undef STAILQ_INIT
++#undef STAILQ_INSERT_AFTER
++#undef STAILQ_INSERT_HEAD
++#undef STAILQ_INSERT_TAIL
++#undef STAILQ_LAST
++#undef STAILQ_REMOVE
++#undef STAILQ_REMOVE_HEAD
++#undef LIST_EMPTY
++#undef LIST_FOREACH
++#undef LIST_FOREACH_SAFE
++#undef LIST_INIT
++#undef LIST_INSERT_AFTER
++#undef LIST_INSERT_BEFORE
++#undef LIST_INSERT_HEAD
++#undef LIST_REMOVE
++#undef TAILQ_HEAD
++#undef TAILQ_HEAD_INITIALIZER
++#undef TAILQ_ENTRY
++#undef TAILQ_CONCAT
++#undef TAILQ_EMPTY
++#undef TAILQ_FOREACH
++#undef TAILQ_FOREACH_SAFE
++#undef TAILQ_FOREACH_REVERSE
++#undef TAILQ_FOREACH_REVERSE_SAFE
++#undef TAILQ_INIT
++#undef TAILQ_INSERT_AFTER
++#undef TAILQ_INSERT_HEAD
++#undef TAILQ_INSERT_TAIL
++#undef TAILQ_REMOVE
++#undef TAILQ_END
++#undef TAILQ_INSERT_BEFORE
++
+ #include "sockem_ctrl.h"
+ 
+ static int sockem_ctrl_thrd_main(void *arg) {


### PR DESCRIPTION
* With 2.0, the linker did not support 31-bit and as such always linked to the 64-bit LE But with 2.1, 31-bit support was added and is the default.

* Enable -Werror flag in compilation